### PR TITLE
Fix getBaseDir deprecaction warning

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -35,7 +35,7 @@
     </change-notes>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="131"/>
+    <idea-version since-build="172.2103.15"/>
 
 
     <depends>com.intellij.modules.lang</depends>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,14 +1,16 @@
 <idea-plugin>
     <id>com.phrase.intellij</id>
     <name>Phrase</name>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <vendor email="support@phrase.com" url="https://www.phrase.com">Phrase</vendor>
 
     <description><![CDATA[
-      Phrase helps you manage Translations in your Android Studio projects. The plugin only support CLI v2 https://github.com/phrase/phrase-cli
+      Phrase helps you manage Translations in your Android Studio projects. The plugin only supports CLI v2 https://github.com/phrase/phrase-cli
     ]]></description>
 
     <change-notes><![CDATA[
+      Version 4.0.1<br/>
+      <em>- Maintenance release</em><br/>
       Version 4.0.0<br/>
       <em>- Released Plugin under new name Phrase. Plugin also only support client v2 https://github.com/phrase/phrase-cli</em><br/>
       Version 3.5.1<br/>

--- a/src/com/phrase/intellij/ProjectLocalesUploader.java
+++ b/src/com/phrase/intellij/ProjectLocalesUploader.java
@@ -1,6 +1,7 @@
 package com.phrase.intellij;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.phrase.intellij.ui.ColorTextPane;
 import org.jetbrains.annotations.NotNull;
@@ -23,7 +24,7 @@ public class ProjectLocalesUploader {
         this.project = project;
         this.remoteProjectId = remoteProjectId;
         this.remoteLocaleNames = getRemoteLocaleNames(api);
-        this.localLocales = ProjectHelper.findProjectLocales(project.getBaseDir());
+        this.localLocales = ProjectHelper.findProjectLocales(ProjectUtil.guessProjectDir(project));
 
     }
 


### PR DESCRIPTION
Remove usage of depreacted API `Project.getBaseDir()`